### PR TITLE
feat: github actions releases and publishing

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,18 @@
+# configuration template for creating a draft GitHub release.
+# see draft-release.yaml for action step.
+# docs:
+# https://github.com/release-drafter/release-drafter
+name-template: 'Release $RESOLVED_VERSION'
+categories:
+  - title: 'Features'
+    label: 'enhancement'
+  - title: 'Bug Fixes'
+    label: 'bug'
+  - title: 'Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,9 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ master ]
+    # don't run when pushing tags
+    tags-ignore: [ "*" ]
 
 jobs:
 

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,0 +1,54 @@
+name: Create Draft Release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  release-draft:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    name: Create Draft Release
+    steps:
+      - name: Get Version Tag
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 'pyproject.toml'
+
+      - name: Check Version Strings
+        run: >
+          TAG=${{ steps.vars.outputs.tag }} 
+          python3 -m pip install toml 
+          && python3 scripts/validate-version.py --check-tag
+
+      - name: Build Wheel & Source
+        run: >
+          python3 -m pip install -U build twine 
+          && python3 -m build 
+          && twine check dist/**
+
+      - name: Draft Release
+        # https://github.com/release-drafter/release-drafter
+        uses: release-drafter/release-drafter@v5
+        with:
+          tag: ${{ steps.vars.outputs.tag }}
+          version: ${{ steps.vars.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload --clobber ${{ steps.vars.outputs.tag }} ./dist/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cedar-solve
+
+    name: PyPi Publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Release Assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download ${{ github.event.release.tag_name }} --dir dist -p "*.whl" -p "*.tar.gz"
+
+      # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
+      # trusted publishing workflow:
+      # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+      - name: Publish To PyPi
+        uses: pypa/gh-action-pypi-publish@v1.9.0

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,19 @@
 Welcome to Cedar-Solve!
 =======================
 
+.. image:: https://img.shields.io/github/license/smroid/cedar-solve
+   :alt: GitHub License
+
+.. image:: https://img.shields.io/github/actions/workflow/status/smroid/cedar-solve/ci.yaml
+   :alt: GitHub Actions Workflow Status
+
+.. image:: https://img.shields.io/pypi/v/cedar-solve
+   :alt: PyPI - Version
+
+.. image:: https://img.shields.io/github/v/release/smroid/cedar-solve
+   :alt: GitHub Release
+
+
 Cedar-Solve is a fork of `esa/tetra3 <https://github.com/esa/tetra3>`_. Please
 refer to that repo for all documentation.
 


### PR DESCRIPTION
new workflows to support creating GitHub releases and publishing wheels to PyPi

- draft-release.yaml
  - when a tag is pushed matching *.*.* this workflow will trigger
  - it will build the wheel and source distributions and upload them to  a new draft GitHub release
  - it will create some descriptions in the release text with recent changes
- publish.yaml
  - when a release is moved from draft to published in the GitHub UI this workflow will trigger
  - it will download the files (wheel, sdist) from the release that was just published and upload them to  PyPi

i added some status badges to the readme
